### PR TITLE
fix cheerio import

### DIFF
--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -1,4 +1,4 @@
-var cheerio = require('cheerio')
+var cheerio = require('cheerio').default
 var marked = require('marked')
 var highlight = require('highlight.js')
 var yaml = require('js-yaml')

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://sourcey.com/spectacle",
   "dependencies": {
     "bluebird": "^3.5.2",
-    "cheerio": "^1.0.0-rc.2",
+    "cheerio": "^1.0.0-rc.10",
     "clarify": "^2.1.0",
     "commander": "*",
     "foundation-sites": "^6.5.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectacle-docs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Generate beautiful static API documentation from OpenAPI/Swagger 2.0 specifications",
   "preferGlobal": true,
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,9 +355,10 @@ cheerio-select@^1.5.0:
     domhandler "^4.2.0"
     domutils "^2.7.0"
 
-cheerio@^1.0.0-rc.2:
+cheerio@^1.0.0-rc.10:
   version "1.0.0-rc.10"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
   dependencies:
     cheerio-select "^1.5.0"
     dom-serializer "^1.3.2"


### PR DESCRIPTION
`yarn swagger:build` in front no longer works, we get errors 'cheerio is not a function'

Testing the `.default` changes manually in front node_modules works, and the build passes

based off fixes other people have mentioned:
https://github.com/wayfair/dociql/issues/36
https://github.com/cheeriojs/cheerio/releases/tag/v1.0.0-rc.9