### PR TITLE
fix: make href target in nav unique when multiple operations for one method and path

### DIFF
--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -29,7 +29,7 @@
         <ul>
           {{#each operations}}
             <li>
-              <a href="#operation-{{htmlId path}}-{{htmlId method}}">
+              <a href="#operation-{{htmlId path}}-{{htmlId method}}-{{htmlId summary}}">
                 {{#if summary}}
                   {{summary}}
                 {{else}}
@@ -49,7 +49,7 @@
         <ul> -->
           {{#each .}}
             <!-- <li> -->
-              <a href="#operation-{{htmlId path}}-{{htmlId method}}">
+              <a href="#operation-{{htmlId path}}-{{htmlId method}}-{{htmlId summary}}">
                 {{#if summary}}
                   {{summary}}
                 {{else}}

--- a/app/views/partials/swagger/operation.hbs
+++ b/app/views/partials/swagger/operation.hbs
@@ -9,8 +9,8 @@
   @api public
 --}}
 
-<div id="operation-{{htmlId path}}-{{htmlId method}}" class="operation panel"
-  data-traverse-target="operation-{{htmlId path}}-{{htmlId method}}">
+<div id="operation-{{htmlId path}}-{{htmlId method}}-{{htmlId summary}}" class="operation panel"
+  data-traverse-target="operation-{{htmlId path}}-{{htmlId method}}-{{htmlId summary}}">
   {{#if tags}}
     <!-- <section class="operation-tags row"> -->
       <!-- <div class="doc-copy"> -->

--- a/public/index.html
+++ b/public/index.html
@@ -27,31 +27,31 @@
             <a href="#tag-Cheese">Cheese</a>
             <ul>
               <li>
-                <a href="#operation--cheeses-post"> Add a new cheese to the store </a>
+                <a href="#operation--cheeses-post-Add-a-new-cheese-to-the-store"> Add a new cheese to the store </a>
               </li>
               <li>
-                <a href="#operation--cheeses-put"> Update an existing cheese </a>
+                <a href="#operation--cheeses-put-Update-an-existing-cheese"> Update an existing cheese </a>
               </li>
               <li>
-                <a href="#operation--cheeses-put"> Update multiple existing cheeses </a>
+                <a href="#operation--cheeses-put-Update-multiple-existing-cheeses"> Update multiple existing cheeses </a>
               </li>
               <li>
-                <a href="#operation--cheeses-findByTags-get"> Finds cheeses by tags </a>
+                <a href="#operation--cheeses-findByTags-get-Finds-cheeses-by-tags"> Finds cheeses by tags </a>
               </li>
               <li>
-                <a href="#operation--cheeses--cheeseId--get"> Find cheese by ID </a>
+                <a href="#operation--cheeses--cheeseId--get-Find-cheese-by-ID"> Find cheese by ID </a>
               </li>
               <li>
-                <a href="#operation--cheeses--cheeseId--post"> Update a cheese </a>
+                <a href="#operation--cheeses--cheeseId--post-Update-a-cheese"> Update a cheese </a>
               </li>
               <li>
-                <a href="#operation--cheeses--cheeseId--delete"> Deletes a cheese </a>
+                <a href="#operation--cheeses--cheeseId--delete-Deletes-a-cheese"> Deletes a cheese </a>
               </li>
               <li>
-                <a href="#operation--cheeses-findByStatus-get"> Finds cheeses by status </a>
+                <a href="#operation--cheeses-findByStatus-get-Finds-cheeses-by-status"> Finds cheeses by status </a>
               </li>
               <li>
-                <a href="#operation--cheeses--cheeseId--uploadImage-post"> Upload a cheese image </a>
+                <a href="#operation--cheeses--cheeseId--uploadImage-post-Upload-a-cheese-image"> Upload a cheese image </a>
               </li>
             </ul>
           </section>
@@ -59,16 +59,16 @@
             <a href="#tag-Store">Store</a>
             <ul>
               <li>
-                <a href="#operation--store-inventory-get"> Return cheese inventories by available status </a>
+                <a href="#operation--store-inventory-get-Return-cheese-inventories-by-available-status"> Return cheese inventories by available status </a>
               </li>
               <li>
-                <a href="#operation--store-order-post"> Place a cheese order </a>
+                <a href="#operation--store-order-post-Place-a-cheese-order"> Place a cheese order </a>
               </li>
               <li>
-                <a href="#operation--store-order--orderId--get"> Find purchase order by ID </a>
+                <a href="#operation--store-order--orderId--get-Find-purchase-order-by-ID"> Find purchase order by ID </a>
               </li>
               <li>
-                <a href="#operation--store-order--orderId--delete"> Delete purchase order by ID </a>
+                <a href="#operation--store-order--orderId--delete-Delete-purchase-order-by-ID"> Delete purchase order by ID </a>
               </li>
             </ul>
           </section>
@@ -76,25 +76,25 @@
             <a href="#tag-Customer">Customer</a>
             <ul>
               <li>
-                <a href="#operation--customer-post"> Create customer account </a>
+                <a href="#operation--customer-post-Create-customer-account"> Create customer account </a>
               </li>
               <li>
-                <a href="#operation--customer-createMultiple-post"> Create multiple customers </a>
+                <a href="#operation--customer-createMultiple-post-Create-multiple-customers"> Create multiple customers </a>
               </li>
               <li>
-                <a href="#operation--customer-login-post"> Customer login </a>
+                <a href="#operation--customer-login-post-Customer-login"> Customer login </a>
               </li>
               <li>
-                <a href="#operation--customer-logout-get"> Customer logout </a>
+                <a href="#operation--customer-logout-get-Customer-logout"> Customer logout </a>
               </li>
               <li>
-                <a href="#operation--customer--username--get"> Get customer by username </a>
+                <a href="#operation--customer--username--get-Get-customer-by-username"> Get customer by username </a>
               </li>
               <li>
-                <a href="#operation--customer--username--put"> Update customer </a>
+                <a href="#operation--customer--username--put-Update-customer"> Update customer </a>
               </li>
               <li>
-                <a href="#operation--customer--username--delete"> Delete customer </a>
+                <a href="#operation--customer--username--delete-Delete-customer"> Delete customer </a>
               </li>
             </ul>
           </section>
@@ -234,7 +234,7 @@
               <p>Cheese methods provide access to information and operations relating to the cheese available in the store.</p>
             </div>
           </div>
-          <div id="operation--cheeses-post" class="operation panel" data-traverse-target="operation--cheeses-post">
+          <div id="operation--cheeses-post-Add-a-new-cheese-to-the-store" class="operation panel" data-traverse-target="operation--cheeses-post-Add-a-new-cheese-to-the-store">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -418,7 +418,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses-put" class="operation panel" data-traverse-target="operation--cheeses-put">
+          <div id="operation--cheeses-put-Update-an-existing-cheese" class="operation panel" data-traverse-target="operation--cheeses-put-Update-an-existing-cheese">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -589,7 +589,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses-put" class="operation panel" data-traverse-target="operation--cheeses-put">
+          <div id="operation--cheeses-put-Update-multiple-existing-cheeses" class="operation panel" data-traverse-target="operation--cheeses-put-Update-multiple-existing-cheeses">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -814,7 +814,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses-findByTags-get" class="operation panel" data-traverse-target="operation--cheeses-findByTags-get">
+          <div id="operation--cheeses-findByTags-get-Finds-cheeses-by-tags" class="operation panel" data-traverse-target="operation--cheeses-findByTags-get-Finds-cheeses-by-tags">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -991,7 +991,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses--cheeseId--get" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--get">
+          <div id="operation--cheeses--cheeseId--get-Find-cheese-by-ID" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--get-Find-cheese-by-ID">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -1150,7 +1150,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses--cheeseId--post" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--post">
+          <div id="operation--cheeses--cheeseId--post-Update-a-cheese" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--post-Update-a-cheese">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -1297,7 +1297,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses--cheeseId--delete" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--delete">
+          <div id="operation--cheeses--cheeseId--delete-Deletes-a-cheese" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--delete-Deletes-a-cheese">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -1423,7 +1423,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses-findByStatus-get" class="operation panel" data-traverse-target="operation--cheeses-findByStatus-get">
+          <div id="operation--cheeses-findByStatus-get-Finds-cheeses-by-status" class="operation panel" data-traverse-target="operation--cheeses-findByStatus-get-Finds-cheeses-by-status">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -1600,7 +1600,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--cheeses--cheeseId--uploadImage-post" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--uploadImage-post">
+          <div id="operation--cheeses--cheeseId--uploadImage-post-Upload-a-cheese-image" class="operation panel" data-traverse-target="operation--cheeses--cheeseId--uploadImage-post-Upload-a-cheese-image">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -1759,7 +1759,7 @@
               <p>Store methods provide access to cheese store orders.</p>
             </div>
           </div>
-          <div id="operation--store-inventory-get" class="operation panel" data-traverse-target="operation--store-inventory-get">
+          <div id="operation--store-inventory-get-Return-cheese-inventories-by-available-status" class="operation panel" data-traverse-target="operation--store-inventory-get-Return-cheese-inventories-by-available-status">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -1882,7 +1882,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--store-order-post" class="operation panel" data-traverse-target="operation--store-order-post">
+          <div id="operation--store-order-post-Place-a-cheese-order" class="operation panel" data-traverse-target="operation--store-order-post-Place-a-cheese-order">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2025,7 +2025,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--store-order--orderId--get" class="operation panel" data-traverse-target="operation--store-order--orderId--get">
+          <div id="operation--store-order--orderId--get-Find-purchase-order-by-ID" class="operation panel" data-traverse-target="operation--store-order--orderId--get-Find-purchase-order-by-ID">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2152,7 +2152,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--store-order--orderId--delete" class="operation panel" data-traverse-target="operation--store-order--orderId--delete">
+          <div id="operation--store-order--orderId--delete-Delete-purchase-order-by-ID" class="operation panel" data-traverse-target="operation--store-order--orderId--delete-Delete-purchase-order-by-ID">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2252,7 +2252,7 @@
               <p>Customer methods contain operations relating to customer accounts.</p>
             </div>
           </div>
-          <div id="operation--customer-post" class="operation panel" data-traverse-target="operation--customer-post">
+          <div id="operation--customer-post-Create-customer-account" class="operation panel" data-traverse-target="operation--customer-post-Create-customer-account">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2342,7 +2342,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--customer-createMultiple-post" class="operation panel" data-traverse-target="operation--customer-createMultiple-post">
+          <div id="operation--customer-createMultiple-post-Create-multiple-customers" class="operation panel" data-traverse-target="operation--customer-createMultiple-post-Create-multiple-customers">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2435,7 +2435,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--customer-login-post" class="operation panel" data-traverse-target="operation--customer-login-post">
+          <div id="operation--customer-login-post-Customer-login" class="operation panel" data-traverse-target="operation--customer-login-post-Customer-login">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2612,7 +2612,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--customer-logout-get" class="operation panel" data-traverse-target="operation--customer-logout-get">
+          <div id="operation--customer-logout-get-Customer-logout" class="operation panel" data-traverse-target="operation--customer-logout-get-Customer-logout">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2665,7 +2665,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--customer--username--get" class="operation panel" data-traverse-target="operation--customer--username--get">
+          <div id="operation--customer--username--get-Get-customer-by-username" class="operation panel" data-traverse-target="operation--customer--username--get-Get-customer-by-username">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2793,7 +2793,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--customer--username--put" class="operation panel" data-traverse-target="operation--customer--username--put">
+          <div id="operation--customer--username--put-Update-customer" class="operation panel" data-traverse-target="operation--customer--username--put-Update-customer">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">
@@ -2930,7 +2930,7 @@
               </div>
             </div>
           </div>
-          <div id="operation--customer--username--delete" class="operation panel" data-traverse-target="operation--customer--username--delete">
+          <div id="operation--customer--username--delete-Delete-customer" class="operation panel" data-traverse-target="operation--customer--username--delete-Delete-customer">
             <!-- <section class="operation-tags row"> -->
             <!-- <div class="doc-copy"> -->
             <div class="operation-tags">


### PR DESCRIPTION
If multiple operations are managed for a single path then the navigation would only navigate to the first operation.